### PR TITLE
让项目在windows下也可用

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "module": "dist/index.esm.js",
   "sideEffects": false,
   "scripts": {
-    "clean": "rm -rf ./dist",
+    "clean": "rimraf ./dist",
     "lint": "eslint -c config/.eslintrc.js src",
     "build:self": "rollup -c config/rollup.config.js",
     "build:esm": "rollup -c config/rollup.config.esm.js",
@@ -33,6 +33,7 @@
     "eslint": "4.18.2",
     "expect.js": "0.3.1",
     "mocha": "3.5.3",
+    "rimraf": "^2.6.2",
     "rollup": "0.57.1",
     "rollup-plugin-babel": "3.0.3",
     "rollup-plugin-commonjs": "8.3.0",

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
   "sideEffects": false,
   "scripts": {
     "clean": "rm -rf ./dist",
-    "lint": "./node_modules/.bin/eslint -c ./config/.eslintrc.js src",
-    "build:self": "./node_modules/rollup/bin/rollup -c config/rollup.config.js",
-    "build:esm": "./node_modules/rollup/bin/rollup -c config/rollup.config.esm.js",
-    "build:aio": "./node_modules/rollup/bin/rollup -c config/rollup.config.aio.js",
+    "lint": "eslint -c config/.eslintrc.js src",
+    "build:self": "rollup -c config/rollup.config.js",
+    "build:esm": "rollup -c config/rollup.config.esm.js",
+    "build:aio": "rollup -c config/rollup.config.aio.js",
     "build": "npm run clean && npm run build:self && npm run build:esm &&  npm run build:aio",
     "test": "npm run lint && npm run build && mocha",
     "release": "npm test && git commit -am $npm_package_version && git tag $npm_package_version && git push && git push --tags"


### PR DESCRIPTION
1. 去除没必要的前缀（`./`这样的路径windows解析会有问题）
2. 添加`rimraf`删除文件，兼容windows

Slove #2 