### PR TITLE
Chore: refactor with dynamic prompts 

### DIFF
--- a/packages/cli/bin/index.js
+++ b/packages/cli/bin/index.js
@@ -1,14 +1,15 @@
 #!/usr/bin/env node
+
 const fs = require('fs');
 const path = require('path');
 const yargs = require('yargs');
+
+const { log } = require('@js-lib/util');
+
 const { runUpdatePrompts, runInitPrompts } = require('./run-prompts');
 const { checkProjectExists } = require('./helpers');
-const pkg = require('../package.json');
-const { log } = require('@js-lib/util');
-const config = require('@js-lib/config');
-
-const cli = require('../index.js');
+const { init } = require('./init');
+const { update } = require('./update');
 
 log()
 
@@ -25,9 +26,21 @@ yargs
         }).option('config', {
             alias: 'c',
             describe: '仅初始化配置文件',
+        }).option('npmname', {
+            alias: 'n',
+            describe: '仅初始化 npm 项目名称',
+        }).option('username', {
+            alias: 'u',
+            describe: '仅初始化用户名称',
+        }).option('type', {
+            alias: 't',
+            describe: '仅初始化 js/ts 选择',
+        }).option('lang', {
+            alias: 'l',
+            describe: '仅初始化中英文选择',
         })
     }, function (argv) {
-        runInitPrompts(argv._[1]).then(function(answers) {
+        runInitPrompts(argv._[1], yargs.argv).then(function(answers) {
             init(argv, answers);
         });
     })
@@ -47,44 +60,5 @@ yargs
     .epilog('copyright 2018-2019')
     .argv;
 
-function init(argv, answers) {
-    const cmdPath = process.cwd();
-    const {name, npmname, username, type, lang} = answers;
-    const pathname = String(typeof argv._[1] !== 'undefined' ? argv._[1] : name);
 
-    const option = {
-        pathname, // 创建的名字
-        name: String(name), // 项目名字 readme 
-        npmname: String(npmname), // 发布到npm的名字，有可能和项目名字不一样，比如带scope
-        umdname: String(npmname).split('/').pop(), // @yan/xxx -> xxx
-        username: String(username),
-        type,
-        lang,
-        version: pkg.version,
-    };
 
-    // 运行命令
-    if (!pathname) {
-        console.error('error: jslib create need name');
-        return;
-    }
-    
-    if (checkProjectExists(cmdPath, pathname) && !argv.force) {
-        console.error('error: The project is already existed! If you really want to override it, use --force argv to bootstrap!');
-        return;
-    }
-
-    config.init(cmdPath, '', option);
-    // 仅初始化配置文件
-    if (argv.config) {
-        return;
-    }
-
-    cli.init(cmdPath, option);
-}
-function update(option, answers) {
-    const cmdPath = process.cwd();
-
-    option.umdname = option.npmname.split('/').pop();
-    cli.update(cmdPath, option, answers);
-}

--- a/packages/cli/bin/init.js
+++ b/packages/cli/bin/init.js
@@ -1,0 +1,42 @@
+const config = require('@js-lib/config');
+const cli = require('../index.js');
+const pkg = require('../package.json');
+const { checkProjectExists } = require('./helpers');
+
+function init(argv, answers) {
+    const cmdPath = process.cwd();
+    const {name, npmname, username, type, lang} = Object.assign({}, argv, answers);
+    const pathname = String(typeof argv._[1] !== 'undefined' ? argv._[1] : name);
+
+    const option = {
+        pathname, // 创建的名字
+        name: String(name), // 项目名字 readme 
+        npmname: String(npmname), // 发布到npm的名字，有可能和项目名字不一样，比如带scope
+        umdname: String(npmname).split('/').pop(), // @yan/xxx -> xxx
+        username: String(username),
+        type,
+        lang,
+        version: pkg.version,
+    };
+
+    // 运行命令
+    if (!pathname) {
+        console.error('error: jslib create need name');
+        return;
+    }
+    
+    if (checkProjectExists(cmdPath, pathname) && !argv.force) {
+        console.error('error: The project is already existed! If you really want to override it, use --force argv to bootstrap!');
+        return;
+    }
+
+    config.init(cmdPath, '', option);
+    // 仅初始化配置文件
+    if (argv.config) {
+        return;
+    }
+
+    cli.init(cmdPath, option);
+}
+
+exports.init = init;

--- a/packages/cli/bin/run-prompts.js
+++ b/packages/cli/bin/run-prompts.js
@@ -11,15 +11,25 @@ function prompts(promptList) {
     })
 };
 
-function runInitPrompts(pathname) {
-    const promptList = [
-        {
+let promptList = [];
+
+function runInitPrompts(pathname, argv) {
+    const {npmname, username, type, lang} = argv
+    if (!pathname) {
+        promptList.push({
             type: 'input',
             message: 'project name:',
             name: 'name',
-            default: pathname,
-        },
-        {
+            validate: function(val) {
+                if (!val) {
+                    return "输入项目名称";
+                }
+                return true
+            }
+        })
+    }
+    if (!npmname) {
+        promptList.push({
             type: 'input',
             message: 'publish to npm name:',
             name: 'npmname',
@@ -30,13 +40,17 @@ function runInitPrompts(pathname) {
                 }
                 return true
             }
-        },
-        {
+        })
+    }
+    if (!username) {
+        promptList.push({
             type: 'input',
             message: 'github user name:',
             name: 'username',
-        },
-        {
+        })
+    }
+    if (!type) {
+        promptList.push({
             type: 'list',
             message: 'use JavaScript|TypeScript:',
             name: 'type',
@@ -50,8 +64,10 @@ function runInitPrompts(pathname) {
                     JavaScript: 'js'
                 }[value])
             }
-        },
-        {
+        })
+    }
+    if (!lang) {
+        promptList.push({
             type: 'list',
             message: 'project language:',
             name: 'lang',
@@ -62,43 +78,19 @@ function runInitPrompts(pathname) {
                     English: 'en',
                 }[value])
             }
-        }
-    ];
+        })
+    }
     return prompts(promptList);
 }
 
 function runUpdatePrompts() {
     const promptList = [
-        // {
-        //     type: 'confirm',
-        //     message: '是否更新<root>插件:',
-        //     name: 'root',
-        //     default: false,
-        // },
         {
             type: 'confirm',
             message: '是否更新<package>插件:',
             name: 'package',
             default: false,
         },
-        // {
-        //     type: 'confirm',
-        //     message: '是否更新<license>插件:',
-        //     name: 'license',
-        //     default: false,
-        // },
-        // {
-        //     type: 'confirm',
-        //     message: '是否更新<readme>插件:',
-        //     name: 'readme',
-        //     default: false,
-        // },
-        // {
-        //     type: 'confirm',
-        //     message: '是否更新<demo>插件:',
-        //     name: 'demo',
-        //     default: false,
-        // },
         {
             type: 'confirm',
             message: '是否更新<src>插件:',

--- a/packages/cli/bin/update.js
+++ b/packages/cli/bin/update.js
@@ -1,0 +1,10 @@
+const cli = require('../index.js');
+
+function update(option, answers) {
+    const cmdPath = process.cwd();
+
+    option.umdname = option.npmname.split('/').pop();
+    cli.update(cmdPath, option, answers);
+}
+
+exports.update = update;


### PR DESCRIPTION
we can use cli argv like:

```
jslib new projectName --npmname npmname --username username --type js/ts --lang en/ch
```

to create new project. 

If we miss some argv, prompts will show up to complete the inputs

